### PR TITLE
Put <a> tag inside <h3> tag

### DIFF
--- a/ctlevent.js
+++ b/ctlevent.js
@@ -68,7 +68,7 @@ CTLEvent.prototype.render = function() {
     return `
         <div class="event">
         <div class="event_specifics">
-        <a href="${this.url}"><h3>${this.title}</h3></a>
+        <h3><a href="${this.url}">${this.title}</a></h3>
         <h4>${this.start} ${this.startTime} - ${this.startTime}</h4>
         </div>
         <div class="event_description"><p>${this.description}</p></div>


### PR DESCRIPTION
When it's the other way around, the clickable area for the `<a>` tag
extends to the whole width of the browser window, beyond the length of
the text.