### PR TITLE
Inject markup

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,16 +10,6 @@
     </head>
     <body>
         <h1>CTL Event testing</h1>
-        <div class="pagination-holder"></div>
-        <div class="search-wrapper">
-            <form role="search">
-                <input id="q" type="text" required="" class="search-box" placeholder="I'm searching for...">
-                <button class="close-icon" id="clear-search" type="reset">Reset</button>
-                <button type="submit" id="search" style="display:none;">Search</button>
-            </form>
-            <div id="search-results"></div>
-        </div>
-        <div id="calendarList"></div>
-        <div class="pagination-holder"></div>
+        <div id="calendar-wrapper"></div>
     </body>
 </html>

--- a/list.js
+++ b/list.js
@@ -1,8 +1,8 @@
-/* global $, jQuery */
+/* global jQuery */
 /* global lunr */
 /* global CTLEvent */
 
-(function() {
+(function($) {
     var ALL_EVENTS = [];
     var FILTERED_EVENTS = [];
 
@@ -119,6 +119,20 @@
     };
 
     jQuery(document).ready(function(){
+        var boilerplate =  '<div class="pagination-holder"></div>' +
+                            '<div class="search-wrapper">' +
+                                '<form role="search">' +
+                                    '<input id="q" type="text" required="" class="search-box" placeholder="I\'m searching for...">' +
+                                    '<button class="close-icon" id="clear-search" type="reset">Reset</button>' +
+                                    '<button type="submit" id="search" style="display:none;">Search</button>' +
+                                '</form>' +
+                                '<div id="search-results"></div>' +
+                            '</div>' +
+                            '<div id="calendarList"></div>' +
+                            '<div class="pagination-holder"></div>';
+
+        jQuery('#calendar-wrapper').append(boilerplate);
+
         jQuery.ajax({
             url: 'https://cdn.cul.columbia.edu/ldpd-toolkit/api/events-bw-prox-v2.json.php',
             type: 'GET',
@@ -151,4 +165,4 @@
             return doSearch(ALL_EVENTS);
         });
     });
-})();
+})(jQuery);


### PR DESCRIPTION
This PR moves the scaffolding markup into list.js.  I did this make it easier to demo on the wordpress site.

It also replaces `$` with `jQuery`.  Wordpress does this to avoid name collisions, and so we must abide.