### PR TITLE
Un-set q URL param

### DIFF
--- a/main.js
+++ b/main.js
@@ -227,6 +227,7 @@
 
             if ($(this).val().length < 2) {
                 refreshEvents(CTLEventsManager.allEvents, 1);
+                CTLEventUtils.unsetURLParams('q');
                 return;
             }
             return doSearch(CTLEventsManager.allEvents);

--- a/utils.js
+++ b/utils.js
@@ -156,7 +156,7 @@ CTLEventUtils.clearURLParams = function() {
  * @param the key to remove
  */
 CTLEventUtils.unsetURLParams = function(key) {
-    if (window.location.search.match(regex)) {
+    if (window.location.search) {
         // this takes in a key, checks to see if it exists, then removes it
         var reString = key + '[=][^&]*';
         var regex = new RegExp(reString, 'i');


### PR DESCRIPTION
This commit unsets the 'q' param in the url when the text query is less
than 2 chars.