### PR TITLE
Greenkeeper/lunr 2.0.1

### DIFF
--- a/events-manager.js
+++ b/events-manager.js
@@ -17,20 +17,12 @@ CTLEventsManager.filteredEvents = [];
  *
  * Returns the array of CTLEvents.
  */
-CTLEventsManager.loadEvents = function(eventsJson, searchIndex) {
-    var i = 0;
+CTLEventsManager.loadEvents = function(eventsJson) {
     var events = [];
 
     eventsJson.forEach(function(eventData) {
         var e = new CTLEvent(eventData);
         events.push(e);
-
-        // build lunr index
-        searchIndex.add({
-            id: i++,
-            title: e.title,
-            description: e.description
-        });
     });
 
     return events;

--- a/main.js
+++ b/main.js
@@ -6,11 +6,27 @@
 
     var ITEMS_ON_PAGE = 6;
 
-    var index = lunr(function() {
-        this.ref('id');
-        this.field('title', {boost: 10});
-        this.field('description', {boost: 5});
-    });
+    var index; 
+
+    var initializeLunrIndex = function(events) {
+        index = lunr(function() {
+            this.ref('id');
+            this.field('title');
+            this.field('description');            
+            var i = 0;
+            var self = this;
+            events.forEach(function(e){
+                // build lunr index
+                self.add({
+                    id: i++,
+                    title: e.title,
+                    description: e.description
+                });
+            });
+        });
+
+        return index;
+    };
 
     var doSearch = function(events) {
         var $el = $('#calendarList');
@@ -66,11 +82,13 @@
         jQuery('#calendarList').append(renderEvents(eArray, pageNum));
     };
 
+
     /**
      * @param events: JSON event object fetched from Bedeworks
      */
     var initializeEventsPage = function(eventsJson) {
-        CTLEventsManager.allEvents = CTLEventsManager.loadEvents(eventsJson, index);
+        CTLEventsManager.allEvents = CTLEventsManager.loadEvents(eventsJson);
+        index = initializeLunrIndex(CTLEventsManager.allEvents);
 
         $('.pagination-holder').pagination({
             items: CTLEventsManager.allEvents.length,

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "tests"
   },
   "dependencies": {
-    "lunr": "^1.0.0",
+    "lunr": "^2.0.1",
     "npm": "^4.2.0"
   },
   "devDependencies": {

--- a/tests/test-utils.js
+++ b/tests/test-utils.js
@@ -13,13 +13,24 @@ describe('searchEvents', function() {
     var json = JSON.parse(fs.readFileSync('./tests/data.json', 'utf8'));
     var events = json.bwEventList.events;
 
-    var index = lunr(function() {
+    var allEvents = CTLEventsManager.loadEvents(events);
+    
+    var index; 
+    index = lunr(function() {
         this.ref('id');
-        this.field('title', {boost: 10});
-        this.field('description', {boost: 5});
+        this.field('title');
+        this.field('description');
+        var self = this;
+        var i = 0;
+        allEvents.forEach(function(e) {
+            // build lunr index
+            self.add({
+                id: i++,
+                title: e.title,
+                description: e.description
+            });
+        });
     });
-
-    var allEvents = CTLEventsManager.loadEvents(events, index);
 
     it('filters events accurately', function() {
         assert.deepEqual(CTLEventUtils.searchEvents(allEvents, index, 'test'), []);


### PR DESCRIPTION
This commit moves the Lunr index building functionality out of a manager
class into main.  The index object in Lunr 2.x is immutable, and so the
index needs to be built when its initialized. Moving this functionality
to main.js permits passing the index to the search functions that
require it.