### PR TITLE
Replace 'Category' PMT# 110782

### DIFF
--- a/ctlevent.js
+++ b/ctlevent.js
@@ -60,6 +60,12 @@ CTLEvent.prototype.getDateObject = function() {
  * Adds the given property to this event's propertyArray.
  */
 CTLEvent.prototype.addProperty = function(name, value) {
+    if (name.match('Category')) {
+        return;
+    }
+    // Replace 'Group-Specific' which is a backend term from Bedeworks to
+    // 'Category'
+    name = name.replace('Group-Specific', 'Category');
     var index = CTLEventUtils.findIndex(this.propertyArray, function(element) {
         return element.name === name;
     });

--- a/tests/test-ctlevent.js
+++ b/tests/test-ctlevent.js
@@ -23,11 +23,10 @@ describe('CTLEvent', function() {
             assert.equal(e.url, events[0].eventlink);
             assert.equal(e.description, events[0].description);
             assert.equal(e.location, events[0].location_address);
-            assert.deepEqual(e.propertyArray[0].values, ['Education']);
-            assert.deepEqual(e.propertyArray[1].values, ['Workshop']);
-            assert.deepEqual(e.propertyArray[2].values, ['Faculty', 'Student']);
-            assert.deepEqual(e.propertyArray[3].values, ['Graduate Students']);
-            assert.deepEqual(e.propertyArray[4].values, ['Medical Center']);
+            assert.deepEqual(e.propertyArray[0].values, ['Workshop']);
+            assert.deepEqual(e.propertyArray[1].values, ['Faculty', 'Student']);
+            assert.deepEqual(e.propertyArray[2].values, ['Graduate Students']);
+            assert.deepEqual(e.propertyArray[3].values, ['Medical Center']);
         });
     });
     describe('render', function() {

--- a/tests/test-ctlevent.js
+++ b/tests/test-ctlevent.js
@@ -24,7 +24,7 @@ describe('CTLEvent', function() {
             assert.equal(e.description, events[0].description);
             assert.equal(e.location, events[0].location_address);
             assert.deepEqual(e.propertyArray[0].values, ['Workshop']);
-            assert.deepEqual(e.propertyArray[1].values, ['Faculty', 'Student']);
+            assert.deepEqual(e.propertyArray[1].values, ['Faculty', 'Graduate Student']);
             assert.deepEqual(e.propertyArray[2].values, ['Graduate Students']);
             assert.deepEqual(e.propertyArray[3].values, ['Medical Center']);
 


### PR DESCRIPTION
This commit drops the 'Category' from the event object and renames
'Group-Specific' to 'Category'.

The initial 'Category' from Bedeworks is meant University-wide and it
has a confusing meaning within the context of the CTL site.
'Group-Specific' was renamed to 'Category' because its one of the few
fields CTL staff can manipulate in Bedeworks. This will allow staff to
more flexibly label events.