### PR TITLE
Add 'Read More' functionality PMT #110778

### DIFF
--- a/ctlevent.js
+++ b/ctlevent.js
@@ -105,22 +105,41 @@ CTLEvent.prototype.getAudience = function() {
 };
 
 CTLEvent.prototype.render = function() {
+    var desc = this.description.trim();
+    var lnBreak = desc.indexOf('.') + 1;
+    var lede = '';
+    var more = '';
+
+    if (lnBreak > 0) {
+        lede = desc.slice(0, lnBreak);
+        more = desc.slice(lnBreak).trim();
+    }
+
     var returnString = '<div class="event">' +
         '<div class="event_specifics">' +
         '<h3><a href="' + this.url +'">' + this.title + '</a></h3>' +
         '<h4>' + this.longDate + ' ' + this.startTime + ' &ndash; '
         + this.endTime + '</h4>' +
         '</div>' +
-        '<div class="event_description"><p>' + this.description + '</p></div>' +
+        '<div class="event_description"><p>' + lede + '</p></div>' +
         '<div class="location"><span class="event_location">' +
         'Location: </span>' + this.location + '</br>'; 
     if (this.roomNumber != '' ) {
-        returnString += '<span class="room_number">Room: ' + this.roomNumber + '</span>';
+        returnString += '<span class="room_number">Room:</span> ' + 
+                         this.roomNumber;
     } 
-    returnString += '</div><div class="event_properties">' +
-        propertiesString(this.propertyArray) + '</div>' +
-        '</div>';
 
+    returnString += '</div><div class="event_properties">' +
+        propertiesString(this.propertyArray) + '</div>'; 
+
+    if (more.length > 0) {
+        returnString += '<div class="more_info">' +
+            '<span id="more_info_trigger">More&hellip; </span>' +
+            '<div class="more_info_container">' + more + '</div>' +
+            '</div>';
+    }
+
+    returnString += '</div>';
     return returnString;
 };
 

--- a/ctlevent.js
+++ b/ctlevent.js
@@ -134,7 +134,7 @@ CTLEvent.prototype.render = function() {
 
     if (more.length > 0) {
         returnString += '<div class="more_info">' +
-            '<span id="more_info_trigger">More&hellip; </span>' +
+            '<span class="more_info_trigger">More&hellip; </span>' +
             '<div class="more_info_container">' + more + '</div>' +
             '</div>';
     }

--- a/list.css
+++ b/list.css
@@ -18,9 +18,18 @@ input { border-radius: 5px; }
 }
 
 .event .event_specifics a:hover { cursor: pointer; }
-.event .location, .event_properties { margin-top: 1em; }
+.event .location, .event_properties, .more_info { margin-top: 1em; }
 .event_properties { }
-.event .location .event_location, .ctl-property-name { font-weight: bold; }
+.event .location .event_location, .room_number, .ctl-property-name { font-weight: bold; }
+
+#more_info_trigger
+{
+    font-weight: bold;
+    cursor: pointer;
+    color: red;
+}
+
+.more_info_container { display: none; }
 
 #loader-animation-container
 {

--- a/list.css
+++ b/list.css
@@ -22,8 +22,7 @@ input { border-radius: 5px; }
 .event_properties { }
 .event .location .event_location, .room_number, .ctl-property-name { font-weight: bold; }
 
-#more_info_trigger
-{
+.more_info_trigger {
     font-weight: bold;
     cursor: pointer;
     color: red;

--- a/main.js
+++ b/main.js
@@ -6,13 +6,13 @@
 
     var ITEMS_ON_PAGE = 6;
 
-    var index; 
+    var index;
 
     var initializeLunrIndex = function(events) {
         index = lunr(function() {
             this.ref('id');
             this.field('title');
-            this.field('description');            
+            this.field('description');
             var i = 0;
             var self = this;
             events.forEach(function(e){
@@ -209,7 +209,7 @@
             '<div class="loader-inner ball-pulse"><div></div><div></div><div></div></div>' +
             '</div>' +
             '<div class="search-wrapper">' +
-            
+
             '<form class="search-container" role="search">' +
             '<input id="q" type="search" required="" class="search-box" ' +
             'placeholder="I\'m searching for...">' +
@@ -230,7 +230,7 @@
             '</label>' +
 
             '<div id="search-results"></div>' +
-            
+
             '</div>' +
             '<div id="calendarList"></div>' +
             '<div class="pagination-holder"></div>';
@@ -270,13 +270,11 @@
             }
             return doSearch(CTLEventsManager.allEvents);
         });
-        function moreInfoAccordion(el) {
-            if (el.target.id == 'more_info_trigger') {
-                $(el.target.nextSibling).toggle();
-            }
-            el.stopPropagation();
-        }
-        document.getElementById('calendarList').addEventListener('click', 
-                                                moreInfoAccordion, false);
+
+        $('#calendarList').on('click', '.more_info_trigger', function() {
+            $(this).closest('.more_info')
+                .find('.more_info_container')
+                .toggle();
+        });
     });
 })(jQuery);

--- a/main.js
+++ b/main.js
@@ -270,5 +270,13 @@
             }
             return doSearch(CTLEventsManager.allEvents);
         });
+        function moreInfoAccordion(el) {
+            if (el.target.id == 'more_info_trigger') {
+                $(el.target.nextSibling).toggle();
+            }
+            el.stopPropagation();
+        }
+        document.getElementById('calendarList').addEventListener('click', 
+                                                moreInfoAccordion, false);
     });
 })(jQuery);


### PR DESCRIPTION
This commit adds a 'Read More' button to each event listing. It splits
the description at the first period. The first sentence is displayed as
a lede, while the rest of the info is behind a 'Read More' toggle.