### PR TITLE
Filter events after a given date.

### DIFF
--- a/events-manager.js
+++ b/events-manager.js
@@ -18,17 +18,17 @@ CTLEventsManager.filteredEvents = [];
  * @param eventsJson = the JSON object in the format provided by
  *                     Bedeworks
  *
- * @param filterAfterDate = a Date object to filter events by. This will
+ * @param startDate = a Date object to filter events by. This will
  *                          filter out events prior to the Date given.
  *
  * @return Returns the array of CTLEvents.
  */
-CTLEventsManager.loadEvents = function(eventsJson, filterAfterDate) {
+CTLEventsManager.loadEvents = function(eventsJson, startDate) {
     var events = [];
 
     eventsJson.forEach(function(eventData) {
         var e = new CTLEvent(eventData);
-        if (filterAfterDate <= e.startDate) {
+        if (startDate <= e.startDate) {
             events.push(e);
         }
     });

--- a/events-manager.js
+++ b/events-manager.js
@@ -15,14 +15,22 @@ CTLEventsManager.filteredEvents = [];
  * instance for each one. This also indexes these items with the
  * given search index.
  *
- * Returns the array of CTLEvents.
+ * @param eventsJson = the JSON object in the format provided by
+ *                     Bedeworks
+ *
+ * @param filterAfterDate = a Date object to filter events by. This will
+ *                          filter out events prior to the Date given.
+ *
+ * @return Returns the array of CTLEvents.
  */
-CTLEventsManager.loadEvents = function(eventsJson) {
+CTLEventsManager.loadEvents = function(eventsJson, filterAfterDate) {
     var events = [];
 
     eventsJson.forEach(function(eventData) {
         var e = new CTLEvent(eventData);
-        events.push(e);
+        if (filterAfterDate <= e.startDate) {
+            events.push(e);
+        }
     });
 
     return events;

--- a/main.js
+++ b/main.js
@@ -89,7 +89,8 @@
      * @param events: JSON event object fetched from Bedeworks
      */
     var initializeEventsPage = function(eventsJson) {
-        CTLEventsManager.allEvents = CTLEventsManager.loadEvents(eventsJson);
+        var now = new Date();
+        CTLEventsManager.allEvents = CTLEventsManager.loadEvents(eventsJson, now);
         index = initializeLunrIndex(CTLEventsManager.allEvents);
 
         $('.pagination-holder').pagination({
@@ -207,89 +208,89 @@
     };
 
     $(document).ready(function() {
-        var boilerplate = 
-        
+        var boilerplate =
+
             '<div id=loader-animation-container>' +
-        
+
             '<div class="loader-inner ball-pulse"><div></div><div></div><div></div></div>' +
-            
+
             '</div>' +
-            
+
             '<div class="search-wrapper">' +
 
             '<div class="search-row" id="search-term">' +
-            
+
             '<div class="search-label">Term</div>' +
-            
+
 
             '<form class="search-container" role="search">' +
-            
+
             '<input id="q" type="search" required="" class="search-box" ' +
-            
+
             'placeholder="Search for...">' +
-            
+
             '<button class="close-icon" id="clear-search" type="reset">' +
-            
+
             'Reset</button>' +
-            
+
             '</form>' +
-            
+
             '</div>' +
-            
-            
-            
+
+
+
             '<div class="search-row" id="search-location">' +
-            
+
             '<div class="search-label">Location</div>' +
-            
+
             '<div id="location-dropdown-container"></div>' +
-           
+
             '</div>' +
-            
-            
-            
+
+
+
             '<div class="search-row" id="search-audience">' +
-            
+
             '<div class="search-label">Audience</div>' +
-            
+
             '<div id="audience-dropdown-container"></div>' +
-           
+
             '</div>' +
-            
-            
-            
+
+
+
             '<div class="search-row" id="search-from">' +
-            
+
             '<div class="search-label">From</div>' +
-            
+
             '<label id="from">' +
             '<input name="start_date" placeholder="Start Date"/>' +
             '</label>' +
-            
+
             '</div>' +
-            
-            
-            
+
+
+
             '<div class="search-row" id="search-to">' +
-            
+
              '<div class="search-label">To</div>' +
-            
+
             '<label id="to"> ' +
             '<input name="end_date" placeholder="End Date" />' +
             '</label>' +
 
             '</div>' +
-                        
+
             '</div>' +
-            
+
             '<div style="clear: both;"></div>' +
-            
+
             '<div id="search-results"></div>' +
 
 
             '<div id="calendarList"></div>' +
-            
-            
+
+
             '<div class="pagination-holder"></div>';
 
         jQuery('#calendar-wrapper').append(boilerplate);

--- a/tests/test-utils.js
+++ b/tests/test-utils.js
@@ -13,9 +13,10 @@ describe('searchEvents', function() {
     var json = JSON.parse(fs.readFileSync('./tests/data.json', 'utf8'));
     var events = json.bwEventList.events;
 
-    var allEvents = CTLEventsManager.loadEvents(events);
-    
-    var index; 
+    var pastDate = new Date(1999, 11, 31, 23, 59);
+    var allEvents = CTLEventsManager.loadEvents(events, pastDate);
+
+    var index;
     index = lunr(function() {
         this.ref('id');
         this.field('title');
@@ -134,7 +135,8 @@ describe('filterOnURLParams', function() {
         this.field('description', {boost: 5});
     });
 
-    var allEvents = CTLEventsManager.loadEvents(events, index);
+    var pastDate = new Date(1999, 11, 31, 23, 59);
+    var allEvents = CTLEventsManager.loadEvents(events, pastDate);
 
     it('returns an array of event objects given params', function() {
         var paramsArray = CTLEventUtils.readURLParams('q=video');
@@ -224,19 +226,19 @@ describe('populateURLParams', function() {
         document.body.innerHTML = searchForm;
         var paramsArray = CTLEventUtils.readURLParams('start=2017-4-18');
         CTLEventUtils.populateURLParams(paramsArray);
-        assert.equal(document.getElementsByName('start_date')[0].value, 
+        assert.equal(document.getElementsByName('start_date')[0].value,
             '4/18/2017');
     });
     it('populates the end date field', function() {
         document.body.innerHTML = searchForm;
         var paramsArray = CTLEventUtils.readURLParams('end=2017-4-18');
         CTLEventUtils.populateURLParams(paramsArray);
-        assert.equal(document.getElementsByName('end_date')[0].value, 
+        assert.equal(document.getElementsByName('end_date')[0].value,
             '4/18/2017');
     });
     it('populates all the fields', function() {
         document.body.innerHTML = searchForm;
-        var paramString = 'q=test&loc=Morningside&audience=Faculty&' + 
+        var paramString = 'q=test&loc=Morningside&audience=Faculty&' +
                           'start=2017-4-18&end=2017-4-18';
         var paramsArray = CTLEventUtils.readURLParams(paramString);
         CTLEventUtils.populateURLParams(paramsArray);
@@ -313,7 +315,8 @@ describe('room number string', function() {
 describe('get event by ID', function() {
     var json = JSON.parse(fs.readFileSync('./tests/data.json', 'utf8'));
     var events = json.bwEventList.events;
-    var allEvents = CTLEventsManager.loadEvents(events);
+    var pastDate = new Date(1999, 11, 31, 23, 59);
+    var allEvents = CTLEventsManager.loadEvents(events, pastDate);
 
     it('checks that an event is found by ID, and that only a single event is returned', function() {
         for (var i = 0; i < events.length; i++) {
@@ -341,7 +344,8 @@ describe('get event by ID', function() {
 describe('sort events by date and time', function() {
     var json = JSON.parse(fs.readFileSync('./tests/data.json', 'utf8'));
     var events = json.bwEventList.events;
-    var allEvents = CTLEventsManager.loadEvents(events);
+    var pastDate = new Date(1999, 11, 31, 23, 59);
+    var allEvents = CTLEventsManager.loadEvents(events, pastDate);
 
     it('checks that an array of event objects is sorted by date', function() {
         var sortedEvents = CTLEventUtils.sortEventsByDate(allEvents);
@@ -368,5 +372,22 @@ describe('take a string and convert it to a date object', function() {
         assert.equal(sampleDate.getDate(), 22);
         assert.equal(sampleDate.getHours(), 13);
         assert.equal(sampleDate.getMinutes(), 15);
+    });
+});
+
+describe('it filters out events older than a given date', function() {
+    it('returns all events when filtered on a date before any in the test set', function() {
+        var json = JSON.parse(fs.readFileSync('./tests/data.json', 'utf8'));
+        var events = json.bwEventList.events;
+        var pastDate = new Date(1999, 11, 31, 23, 59);
+        var allEvents = CTLEventsManager.loadEvents(events, pastDate);
+        assert.equal(allEvents.length, 15);
+    });
+    it('returns no events when filtered on a date far far in the future', function() {
+        var json = JSON.parse(fs.readFileSync('./tests/data.json', 'utf8'));
+        var events = json.bwEventList.events;
+        var futureDate = new Date(2999, 11, 31, 23, 59);
+        var allEvents = CTLEventsManager.loadEvents(events, futureDate);
+        assert.equal(allEvents.length, 0);
     });
 });


### PR DESCRIPTION
This commit introduces the feature to filter out date after a given
date, upstream from the existing date filering functionality.

Why was this needed?
We switched to using our own JSON proxy for event data.  We found that
when the proxy fails to update, events in the past would appear in the
calendar.

There's alredy a date filter, why another one?
It made sense to add it 'upstream' at the point where event objects are
instatiated so that it wouldn't conflict with the user facing filtering.
It would be possible to set an initial date filter using the current
functions, but if a user reset the filters, old events would appear.