### PR TITLE
Show registration button PMT#: 111804

### DIFF
--- a/ctlevent.js
+++ b/ctlevent.js
@@ -56,7 +56,6 @@ var CTLEvent = function(event) {
     this.status = event.status;
     this.description = event.description;
     this.registration = false;
-    this.registrationLink = '';
 
     this.propertyArray = [];
 
@@ -75,13 +74,9 @@ var CTLEvent = function(event) {
 
             this.addProperty(propList[0], propList[1]);
         }
-        // construct url for CAS login to register
-        if (xprop[i]['X-BEDEWORK-UNI-ONLY-REG']) {
+
+        if (xprop[i]['X-BEDEWORK-REGISTRATION-START']) {
             this.registration = true;
-            this.registrationLink = 'https://cas.columbia.edu/cas/login?service=';
-            this.registrationLink += this.url.replace('http', 'https');
-            this.registrationLink += '%26setappvar=cas(true)';
-            this.registrationLink = this.registrationLink.replace(/&/g, '%26');
         }
     }
 };
@@ -169,8 +164,8 @@ CTLEvent.prototype.render = function() {
 
     if (this.registration) {
         returnString += '<div class="event_registration">' +
-                        '<a target="_blank"  href="' + this.registrationLink + '">' +
-                        '<button>Register With UNI</button></a></div>';
+                        '<a target="_blank"  href="' + this.url + '">' +
+                        '<button>Register on CU Events</button></a></div>';
     }
 
     returnString += '<div class="event_properties">' +

--- a/tests/test-ctlevent.js
+++ b/tests/test-ctlevent.js
@@ -23,18 +23,13 @@ describe('CTLEvent', function() {
             assert.equal(e.endTime, events[0].end.time);
             assert.equal(e.url, events[0].eventlink);
             assert.equal(e.description, events[0].description);
-            // is this a valid test?
             assert.equal(e.location, CTLEventUtils.getRoomNumber(events[0].location.address)[0]);
             assert.equal(e.roomNumber, CTLEventUtils.getRoomNumber(events[0].location.address)[1]);
             assert.deepEqual(e.propertyArray[0].values, ['Workshop']);
             assert.deepEqual(e.propertyArray[1].values, ['Staff', 'Faculty']);
             assert.deepEqual(e.propertyArray[2].values, ['CourseWorks']);
             assert.deepEqual(e.propertyArray[3].values, ['Morningside']);
-            if (e.registration) {
-                assert.notEqual(e.registrationLink, '');
-            } else {
-                assert.equal(e.registrationLink, '');
-            }
+            assert(e.registration);
         });
     });
     describe('render', function() {


### PR DESCRIPTION
This commit changes the behavior of the registration button such that it
will appear for either a registration that requires a UNI and ones that
don't. It links the button back to Bedeworks to handle the work of
registration.