### PR TITLE
Fix date filtering bug PMT#: 111811

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -84,14 +84,14 @@ CTLEventUtils.filterEventsByDateRange = function(allEvents, startDate, endDate) 
     allEvents.forEach(function(e) {
         if (startDate && endDate) {
             if (
-                e.startDate() >= startDate &&
-                    e.startDate() <= endDate
+                e.startDate >= startDate &&
+                    e.startDate <= endDate
             ) {
                 events.push(e);
             }
-        } else if (startDate && e.startDate() >= startDate) {
+        } else if (startDate && e.startDate >= startDate) {
             events.push(e);
-        } else if (endDate && e.startDate() <= endDate) {
+        } else if (endDate && e.startDate <= endDate) {
             events.push(e);
         }
     });


### PR DESCRIPTION
This commit fixes a bug with the date filter function. Prior, the
startDate and endDate were changed from methods to instance variables.
The filter function wasn't updated and so it was calling functions that
didn't exist.