### PR TITLE
Remove un-needed date time strings from event.

### DIFF
--- a/ctlevent.js
+++ b/ctlevent.js
@@ -29,7 +29,6 @@ var CTLEvent = function(event) {
     this.title = event.summary;
 
     // check for specific properties in event object before assigning values
-    this.formattedDate = event.formattedDate;
     this.startDate = '';
     if ('start' in event) {
         this.startDate = CTLEventUtils.strToDate(event.start.datetime);
@@ -125,6 +124,8 @@ CTLEvent.prototype.render = function() {
     var lnBreak = desc.indexOf('.') + 1;
     var lede = '';
     var more = '';
+    var options = {weekday: 'long', year: 'numeric', month: 'long', day: 'numeric'};
+    var timeOptions = {hour: '2-digit', minute: '2-digit'};
 
     if (lnBreak > 0) {
         lede = desc.slice(0, lnBreak);
@@ -140,7 +141,10 @@ CTLEvent.prototype.render = function() {
     returnString += '<a href="' + this.url +'">' + this.title + '</a>';
     if (this.status == 'CANCELLED') {returnString += '</span>';}
 
-    returnString += '</h3><h4>' + this.formattedDate + '</h4>' +
+    returnString += '</h3><h4>' + this.startDate.toLocaleString('en-US', options) + '<br/>' +
+        this.startDate.toLocaleTimeString('en-US', timeOptions) + '&ndash;' +
+        this.endDate.toLocaleTimeString('en-US', timeOptions) +
+        '</h4>' +
         '</div>' +
         '<div class="event_description"><p>' + lede;
     if (more.length > 0) {
@@ -170,6 +174,9 @@ CTLEvent.prototype.render = function() {
 };
 
 CTLEvent.prototype.renderHomepageEvent = function() {
+    var options = {weekday: 'long', year: 'numeric', month: 'long', day: 'numeric'};
+    var timeOptions = {hour: '2-digit', minute: '2-digit'};
+
     var returnString = '<div class="event">' +
         '<div class="event_specifics"><h4>';
     // check the event status
@@ -179,8 +186,10 @@ CTLEvent.prototype.renderHomepageEvent = function() {
     returnString += '<a href="' + this.url +'">' + this.title + '</a>';
     if (this.status == 'CANCELLED') {returnString += '</span>';}
 
-    returnString += '</h4><h5>' + this.formattedDate + '</h5>' +
-        '</div>';
+    returnString += '</h4><h5>' + this.startDate.toLocaleString('en-US', options) + '<br/>' +
+        this.startDate.toLocaleTimeString('en-US', timeOptions) + '&ndash;' +
+        this.endDate.toLocaleTimeString('en-US', timeOptions) +
+        '</h5></div>';
 
     return returnString;
 };

--- a/tests/test-ctlevent.js
+++ b/tests/test-ctlevent.js
@@ -18,7 +18,8 @@ describe('CTLEvent', function() {
             var e = new CTLEvent(events[0]);
             assert.equal(e.id, events[0].guid);
             assert.equal(e.title, events[0].summary);
-            assert.equal(e.formattedDate, events[0].formattedDate);
+            assert.deepEqual(e.startDate, CTLEventUtils.strToDate(events[0].start.datetime));
+            assert.deepEqual(e.endDate, CTLEventUtils.strToDate(events[0].end.datetime));
             assert.equal(e.url, events[0].eventlink);
             assert.equal(e.description, events[0].description);
             assert.equal(e.location, CTLEventUtils.getRoomNumber(events[0].location.address)[0]);


### PR DESCRIPTION
Removes some cruft from the event constructor. Also reformates how date
and time is printed to the page.