### PR TITLE
Patch bug reading out of Lunr index PMT# 112228

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -490,6 +490,10 @@ CTLEventUtils.filterEvents = function(allEvents, lunrIndex, q, loc, audience, st
     }
 
     // first check that the parameters exist, then call the filters
+    if (q) {
+        eventsList = CTLEventUtils.searchEvents(eventsList, lunrIndex, q);
+        CTLEventUtils.updateURL('q', q);
+    }
     if (startDate || endDate) {
         eventsList = CTLEventUtils.filterEventsByDateRange(eventsList, startDate, endDate);
         if (startDate) {
@@ -506,10 +510,6 @@ CTLEventUtils.filterEvents = function(allEvents, lunrIndex, q, loc, audience, st
     if (audience) {
         eventsList = CTLEventUtils.filterEventsByAudience(eventsList, audience);
         CTLEventUtils.updateURL('audience', audience);
-    }
-    if (q) {
-        eventsList = CTLEventUtils.searchEvents(eventsList, lunrIndex, q);
-        CTLEventUtils.updateURL('q', q);
     }
     if (eventID) {
         eventsList = CTLEventUtils.getEventByID(eventsList, eventID);


### PR DESCRIPTION
The searchEvents function uses an array index to fetch results out of
the result which are derived from a list of all events. There exists a
mismatch between the array of events that have been filtered down and
the set of all events.

This patch moves the text filter to be first among the filters so the
array indices match up. Its a temp fix until the searchEvents function
is debugged.