### PR TITLE
Fixes bug where all-day events were being filtered out of results

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -340,21 +340,29 @@ CTLEventUtils.strToDate = function(dateString) {
     // YYYYMMDDTHHMMSS
     // where T is the literal letter 'T'
     // and all others are ints
-    if (dateString.length != 15) {return null;}
+    // OR, if an all day event
+    // YYYYMMDD
+    let allDayRE = /^\d{8}$/;
+    let dateTimeRE = /^\d{8}T\d{6}$/;
 
-    var year = Number(dateString.substr(0, 4));
-    var month = Number(dateString.substr(4, 2)) - 1;
-    var date = Number(dateString.substr(6, 2));
-    var hours = Number(dateString.substr(9, 2));
-    var min = Number(dateString.substr(11, 2));
+    if (allDayRE.test(dateString) || dateTimeRE.test(dateString)) {
+        let year = Number(dateString.substr(0, 4));
+        let month = Number(dateString.substr(4, 2)) - 1;
+        let date = Number(dateString.substr(6, 2));
+        let hours = Number(dateString.substr(9, 2));
+        let min = Number(dateString.substr(11, 2));
 
-    var dateObject = new Date(year, month, date, hours, min);
-    // rely on the Date constructor to test for validity
-    if (dateObject instanceof Date) {
-        return dateObject;
-    } else {
-        return null;
+        let dateObject = new Date(year, month, date, hours, min);
+        // rely on the Date constructor to test for validity
+        if (dateObject instanceof Date) {
+            return dateObject;
+        } else {
+            return null;
+        }
     }
+
+    return null;
+
 };
 
 /**

--- a/tests/test-utils.js
+++ b/tests/test-utils.js
@@ -329,7 +329,7 @@ describe('take a string and convert it to a date object', function() {
         var sampleDate = CTLEventUtils.strToDate('FOOBAR');
         assert.equal(sampleDate, null);
     });
-    it('returns a date object when given a string in the correct format', function() {
+    it('returns a date object when given a string in the format for an event of a few hours', function() {
         var sampleDate = CTLEventUtils.strToDate('20170622T131500');
         assert(sampleDate instanceof Date);
         assert.equal(sampleDate.getFullYear(), 2017);
@@ -337,6 +337,15 @@ describe('take a string and convert it to a date object', function() {
         assert.equal(sampleDate.getDate(), 22);
         assert.equal(sampleDate.getHours(), 13);
         assert.equal(sampleDate.getMinutes(), 15);
+    });
+    it('returns a date object when given a string in the format for an all day event', function() {
+        var sampleDate = CTLEventUtils.strToDate('20170622');
+        assert(sampleDate instanceof Date);
+        assert.equal(sampleDate.getFullYear(), 2017);
+        assert.equal(sampleDate.getMonth(), 5);
+        assert.equal(sampleDate.getDate(), 22);
+        assert.equal(sampleDate.getHours(), 0);
+        assert.equal(sampleDate.getMinutes(), 0);
     });
 });
 


### PR DESCRIPTION
This mitigates a bug in Bedeworks where the datetime string for all-day
events are truncated to remove the time. This change parses for either
form of the date string.