### PR TITLE
Update imports-loader conf

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -5,7 +5,7 @@
 let jQuery = require('jquery');
 import 'jquery-ui-dist/jquery-ui.min.js';
 import 'jquery-ui-dist/jquery-ui.min.css';
-require('imports-loader?jQuery=jquery!../../lib/jquery.simplePagination.js');
+require('imports-loader?imports=jQuery|jquery!../../lib/jquery.simplePagination.js');
 import '../../lib/simplePagination.css';
 import '../../lib/loaders.min.css';
 


### PR DESCRIPTION
This project uses a library called imports-loader. It injects module
level variables into dependencies. In this case its used to load jQuery
into simplePagination.js as 'jquery'.

This commit fixes a breaking change in ee8ae4e to the configuration of
the loader.