### PR TITLE
CW-552 HTML parsing bug

### DIFF
--- a/src/js/ctlevent.js
+++ b/src/js/ctlevent.js
@@ -117,12 +117,14 @@ CTLEvent.prototype.getAudience = function() {
 CTLEvent.prototype.render = function() {
     var parsedString = CTLEventUtils.parseHtml(this.description);
     var desc = new Range().createContextualFragment(parsedString);
-    var lede = desc.firstElementChild.innerHTML;
+    var lede = desc.firstElementChild ? desc.firstElementChild.innerHTML : '';
     var more = '';
     if (desc.childElementCount > 1) {
         desc.removeChild(desc.firstElementChild);
         more = [...desc.children].reduce(function(acc, val){
-            acc += val.innerHTML;
+            if (val && val.innerHTML) {
+                acc += val.innerHTML;
+            }
             return acc;
         }, '');
     }

--- a/src/js/ctlevent.js
+++ b/src/js/ctlevent.js
@@ -115,17 +115,20 @@ CTLEvent.prototype.getAudience = function() {
 };
 
 CTLEvent.prototype.render = function() {
-    var desc = this.description.trim();
-    var lnBreak = desc.indexOf('.') + 1;
-    var lede = '';
+    var parsedString = CTLEventUtils.parseHtml(this.description);
+    var desc = new Range().createContextualFragment(parsedString);
+    var lede = desc.firstElementChild.innerHTML;
     var more = '';
+    if (desc.childElementCount > 1) {
+        desc.removeChild(desc.firstElementChild);
+        more = [...desc.children].reduce(function(acc, val){
+            acc += val.innerHTML;
+            return acc;
+        }, '');
+    }
     var options = {weekday: 'long', year: 'numeric', month: 'long', day: 'numeric'};
     var timeOptions = {hour: 'numeric', minute: '2-digit'};
 
-    if (lnBreak > 0) {
-        lede = desc.slice(0, lnBreak);
-        more = desc.slice(lnBreak).trim();
-    }
 
     var returnString = '<div class="event">' +
         '<div class="event_specifics"><h3 class="ctl-event-title">';

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -531,4 +531,8 @@ CTLEventUtils.filterEvents = function(allEvents, lunrIndex, q, loc, audience, st
     return eventsList;
 };
 
+CTLEventUtils.parseHtml = function(string) {
+    return new DOMParser().parseFromString(string, 'text/html').documentElement.textContent;
+};
+
 export { CTLEventUtils };

--- a/tests/test-ctlevent.js
+++ b/tests/test-ctlevent.js
@@ -5,6 +5,8 @@ var assert = require('assert');
 var CTLEvent = require('../src/js/ctlevent.js').CTLEvent;
 var CTLEventUtils = require('../src/js/utils.js').CTLEventUtils;
 import json from './data.json';
+global.DOMParser = window.DOMParser;
+global.Range = window.Range;
 
 describe('CTLEvent', function() {
     var events = json.bwEventList.events;


### PR DESCRIPTION
This commit fixes a bug likely introduced by Bedeworks escaping emitted
HTML. This commit parses the HTML, and then parses it into a document
fragment.

It also fixes an issue where the 'lede' and 'more' text was
was being split on the first appearance of a '.'. This now parses it
into a document fragment so the markup can be handled as DOM nodes. The
lede is now the first child node, and 'more' are the remaining nodes.
